### PR TITLE
fix cocotb assignment using '<='

### DIFF
--- a/AhbLite3.py
+++ b/AhbLite3.py
@@ -140,7 +140,7 @@ class AhbLite3Terminaison:
             self.doComb()
 
     def doComb(self):
-        self.ahb.HREADY <= self.randomHREADY and (int(self.ahb.HREADYOUT) == 1)
+        self.ahb.HREADY <= (self.randomHREADY and (int(self.ahb.HREADYOUT) == 1))
 
 
 class AhbLite3MasterReadChecker:


### PR DESCRIPTION
It seems that either Python3 or Cocotb (or both) have changed in regards 
to precedence of '<=' with 'and'.

At least `spinal.tester.scalatest.AhbLite3OnChipRamTesterCocotbBoot` requires this fix to work properly without a Cocotb error.