### PR TITLE
Fix lockup with GHDL 1.0

### DIFF
--- a/Stream.py
+++ b/Stream.py
@@ -156,7 +156,6 @@ class StreamMonitor:
     @cocotb.coroutine
     def stim(self):
         stream = self.stream
-        stream.valid <= 0
         while True:
             yield RisingEdge(self.clk)
             if int(stream.valid) == 1 and int(stream.ready) == 1:


### PR DESCRIPTION
It seems that GHDL 1.0+ changed its behavior about DUT output signals that are driven from the cocotb testbench: if we set a stream.valid output to 0 in a monitor, it actually stays low instead of showing the actual DUT stream.valid signal in the monitor and the slave verification module.

I don’t know why we thought it was a good idea to force this output signal low, but it should be better now.