### PR TITLE
Cleanup 03of20: cocotb.fork is deprecated

### DIFF
--- a/AhbLite3.py
+++ b/AhbLite3.py
@@ -103,7 +103,7 @@ class AhbLite3MasterDriver:
         self.clk = clk
         self.reset = reset
         self.transactor = transactor
-        cocotb.fork(self.stim())
+        cocotb.start_soon(self.stim())
 
     @cocotb.coroutine
     def stim(self):
@@ -139,8 +139,8 @@ class AhbLite3Terminaison:
         self.clk = clk
         self.reset = reset
         self.randomHREADY = True
-        cocotb.fork(self.stim())
-        cocotb.fork(self.combEvent())
+        cocotb.start_soon(self.stim())
+        cocotb.start_soon(self.combEvent())
 
     @cocotb.coroutine
     def stim(self):
@@ -169,7 +169,7 @@ class AhbLite3MasterReadChecker:
         self.reset = reset
         self.buffer = buffer
         self.counter = 0
-        cocotb.fork(self.stim())
+        cocotb.start_soon(self.stim())
 
     @cocotb.coroutine
     def stim(self):
@@ -204,8 +204,8 @@ class AhbLite3SlaveMemory:
         self.size = size
         self.ram = bytearray(b'\x00' * size)
 
-        cocotb.fork(self.stim())
-        cocotb.fork(self.stimReady())
+        cocotb.start_soon(self.stim())
+        cocotb.start_soon(self.stimReady())
 
     @cocotb.coroutine
     def stimReady(self):

--- a/AhbLite3.py
+++ b/AhbLite3.py
@@ -8,14 +8,14 @@ from cocotblib.misc import log2Up, BoolRandomizer, assertEquals
 
 
 def AhbLite3MasterIdle(ahb):
-    ahb.HADDR <= 0
-    ahb.HWRITE <= 0
-    ahb.HSIZE <= 0
-    ahb.HBURST <= 0
-    ahb.HPROT <= 0
-    ahb.HTRANS <= 0
-    ahb.HMASTLOCK <= 0
-    ahb.HWDATA <= 0
+    ahb.HADDR.value = 0
+    ahb.HWRITE.value = 0
+    ahb.HSIZE.value = 0
+    ahb.HBURST.value = 0
+    ahb.HPROT.value = 0
+    ahb.HTRANS.value = 0
+    ahb.HMASTLOCK.value = 0
+    ahb.HWDATA.value = 0
 
 
 
@@ -108,14 +108,14 @@ class AhbLite3MasterDriver:
     @cocotb.coroutine
     def stim(self):
         ahb = self.ahb
-        ahb.HADDR     <= 0
-        ahb.HWRITE    <= 0
-        ahb.HSIZE     <= 0
-        ahb.HBURST    <= 0
-        ahb.HPROT     <= 0
-        ahb.HTRANS    <= 0
-        ahb.HMASTLOCK <= 0
-        ahb.HWDATA    <= 0
+        ahb.HADDR.value     = 0
+        ahb.HWRITE.value    = 0
+        ahb.HSIZE.value     = 0
+        ahb.HBURST.value    = 0
+        ahb.HPROT.value     = 0
+        ahb.HTRANS.value    = 0
+        ahb.HMASTLOCK.value = 0
+        ahb.HWDATA.value    = 0
         HWDATAbuffer = 0
         while True:
             for trans in self.transactor.getTransactions():
@@ -123,14 +123,14 @@ class AhbLite3MasterDriver:
                 while int(self.ahb.HREADY) == 0:
                     yield RisingEdge(self.clk)
 
-                ahb.HADDR <= trans.HADDR
-                ahb.HWRITE <= trans.HWRITE
-                ahb.HSIZE <= trans.HSIZE
-                ahb.HBURST <= trans.HBURST
-                ahb.HPROT <= trans.HPROT
-                ahb.HTRANS <= trans.HTRANS
-                ahb.HMASTLOCK <= trans.HMASTLOCK
-                ahb.HWDATA <= HWDATAbuffer
+                ahb.HADDR.value = trans.HADDR
+                ahb.HWRITE.value = trans.HWRITE
+                ahb.HSIZE.value = trans.HSIZE
+                ahb.HBURST.value = trans.HBURST
+                ahb.HPROT.value = trans.HPROT
+                ahb.HTRANS.value = trans.HTRANS
+                ahb.HMASTLOCK.value = trans.HMASTLOCK
+                ahb.HWDATA.value = HWDATAbuffer
                 HWDATAbuffer = trans.HWDATA
 
 class AhbLite3Terminaison:
@@ -145,8 +145,8 @@ class AhbLite3Terminaison:
     @cocotb.coroutine
     def stim(self):
         randomizer = BoolRandomizer()
-        self.ahb.HREADY <= 1
-        self.ahb.HSEL <= 1
+        self.ahb.HREADY.value = 1
+        self.ahb.HSEL.value = 1
         while True:
             yield RisingEdge(self.clk)
             self.randomHREADY = randomizer.get()
@@ -159,7 +159,7 @@ class AhbLite3Terminaison:
             self.doComb()
 
     def doComb(self):
-        self.ahb.HREADY <= (self.randomHREADY and (int(self.ahb.HREADYOUT) == 1))
+        self.ahb.HREADY.value = (self.randomHREADY and (int(self.ahb.HREADYOUT) == 1))
 
 
 class AhbLite3MasterReadChecker:
@@ -210,7 +210,7 @@ class AhbLite3SlaveMemory:
     @cocotb.coroutine
     def stimReady(self):
         randomizer = BoolRandomizer()
-        self.ahb.HREADYOUT <= 1
+        self.ahb.HREADYOUT.value = 1
         busy = False
         while True:
             yield RisingEdge(self.clk)
@@ -222,16 +222,16 @@ class AhbLite3SlaveMemory:
                 raise TestFailure("HREADYOUT == 0 but HREADY == 1 ??? " + self.ahb.HREADY._name)
             busy = busyNew
             if (busy):
-                self.ahb.HREADYOUT <= randomizer.get() # make some random delay for NONSEQ and SEQ requests
+                self.ahb.HREADYOUT.value = randomizer.get()  # make some random delay for NONSEQ and SEQ requests
             else:
-                self.ahb.HREADYOUT <= 1 # IDLE and BUSY require 0 WS
+                self.ahb.HREADYOUT.value = 1  # IDLE and BUSY require 0 WS
 
     @cocotb.coroutine
     def stim(self):
         ahb = self.ahb
-        ahb.HREADYOUT <= 1
-        ahb.HRESP     <= 0
-        ahb.HRDATA    <= 0
+        ahb.HREADYOUT.value = 1
+        ahb.HRESP.value     = 0
+        ahb.HRDATA.value    = 0
         valid = 0
         while True:
             yield RisingEdge(self.clk)
@@ -252,7 +252,7 @@ class AhbLite3SlaveMemory:
             address = int(ahb.HADDR)
             addressOffset = address % (len(ahb.HWDATA)//8)
 
-            ahb.HRDATA <= 0
+            ahb.HRDATA.value = 0
             if valid == 1:
                 if trans >= 2:
                     if write == 0:
@@ -261,4 +261,4 @@ class AhbLite3SlaveMemory:
                             data |= self.ram[address-self.base + idx] << (8*(addressOffset + idx))
                             # print("read %x with %x" % (address + idx, self.ram[address-self.base + idx]))
                         # print(str(data))
-                        ahb.HRDATA <= int(data)
+                        ahb.HRDATA.value = int(data)

--- a/AhbLite3.py
+++ b/AhbLite3.py
@@ -4,7 +4,7 @@ import cocotb
 from cocotb.result import TestFailure
 from cocotb.triggers import RisingEdge, Edge
 
-from cocotblib.misc import log2Up, BoolRandomizer, assertEquals
+from .misc import log2Up, BoolRandomizer, assertEquals
 
 
 def AhbLite3MasterIdle(ahb):

--- a/Apb3.py
+++ b/Apb3.py
@@ -20,7 +20,7 @@ class Apb3:
         self.PRDATA    = dut.__getattr__(name + "_PRDATA")
 
     def idle(self):
-        self.PSEL <= 0
+        self.PSEL.value = 0
 
     @coroutine
     def delay(self, cycle):
@@ -29,16 +29,16 @@ class Apb3:
 
     @coroutine
     def write(self, address, data, sel = 1):
-        self.PADDR <= address
-        self.PSEL <= sel
-        self.PENABLE <= False
-        self.PWRITE <= True
-        self.PWDATA <= data
+        self.PADDR.value = address
+        self.PSEL.value = sel
+        self.PENABLE.value = False
+        self.PWRITE.value = True
+        self.PWDATA.value = data
         yield RisingEdge(self.clk)
-        self.PENABLE <= True
+        self.PENABLE.value = True
         yield waitClockedCond(self.clk, lambda : self.PREADY == True)
         randSignal(self.PADDR)
-        self.PSEL <= 0
+        self.PSEL.value = 0
         randSignal(self.PENABLE)
         randSignal(self.PWRITE)
         randSignal(self.PWDATA)
@@ -51,16 +51,16 @@ class Apb3:
 
     @coroutine
     def read(self, address, sel=1):
-        self.PADDR <= address
-        self.PSEL <= sel
-        self.PENABLE <= False
-        self.PWRITE <= False
+        self.PADDR.value = address
+        self.PSEL.value = sel
+        self.PENABLE.value = False
+        self.PWRITE.value = False
         randSignal(self.PWDATA)
         yield RisingEdge(self.clk)
-        self.PENABLE <= True
+        self.PENABLE.value = True
         yield waitClockedCond(self.clk, lambda: self.PREADY == True)
         randSignal(self.PADDR)
-        self.PSEL <= 0
+        self.PSEL.value = 0
         randSignal(self.PENABLE)
         randSignal(self.PWRITE)
         raise ReturnValue(int(self.PRDATA))

--- a/Apb3.py
+++ b/Apb3.py
@@ -5,7 +5,7 @@ from cocotb.decorators import coroutine
 from cocotb.result import TestFailure, ReturnValue
 from cocotb.triggers import RisingEdge, Edge
 
-from cocotblib.misc import log2Up, BoolRandomizer, assertEquals, waitClockedCond, randSignal
+from .misc import log2Up, BoolRandomizer, assertEquals, waitClockedCond, randSignal
 
 
 class Apb3:

--- a/Axi4.py
+++ b/Axi4.py
@@ -1,11 +1,11 @@
 import random
 from queue import Queue
 
-from cocotblib.Phase import PHASE_SIM, Infrastructure
-from cocotblib.Scorboard import ScorboardOutOfOrder
-from cocotblib.misc import BoolRandomizer, log2Up, randBits
+from .Phase import PHASE_SIM, Infrastructure
+from .Scorboard import ScorboardOutOfOrder
+from .misc import BoolRandomizer, log2Up, randBits
 
-from cocotblib.Stream import Stream, Transaction, StreamDriverSlave, StreamDriverMaster, StreamMonitor
+from .Stream import Stream, Transaction, StreamDriverSlave, StreamDriverMaster, StreamMonitor
 
 
 class Axi4:

--- a/Axi4.py
+++ b/Axi4.py
@@ -74,8 +74,8 @@ class Axi4SharedMemoryChecker(Infrastructure):
         StreamDriverMaster(axi.w, self.genWriteData, clk, reset)
         StreamMonitor(axi.r, self.onReadRsp, clk, reset)
         StreamMonitor(axi.b, self.onWriteRsp, clk, reset)
-        axi.w.payload.last <= 0
-        axi.r.payload.last <= 0
+        axi.w.payload.last.value = 0
+        axi.r.payload.last.value = 0
 
     def freeReservatedAddresses(self,uut,ref,equal):
         self.reservedAddresses.pop(ref,None)

--- a/ClockDomain.py
+++ b/ClockDomain.py
@@ -17,7 +17,7 @@ class RESET_ACTIVE_LEVEL:
 #
 #    # Create a clock with a reset active high
 #    clockDomain = ClockDomain(dut.clk, 400, dut.reset, RESET_ACTIVE_LEVEL.HIGH)
-#    cocobt.fork( clockDomain.start() )
+#    cocotb.start_soon( clockDomain.start() )
 #
 class ClockDomain:
 
@@ -45,9 +45,9 @@ class ClockDomain:
     @cocotb.coroutine
     def start(self):
 
-        self.fork_gen = cocotb.fork(self._clkGen())
+        self.fork_gen = cocotb.start_soon(self._clkGen())
         if self.reset != None :
-            cocotb.fork(self._waitEndReset())
+            cocotb.start_soon(self._waitEndReset())
 
         if self.reset:
             self.reset.value = self.typeReset

--- a/ClockDomain.py
+++ b/ClockDomain.py
@@ -50,12 +50,12 @@ class ClockDomain:
             cocotb.fork(self._waitEndReset())
 
         if self.reset:
-            self.reset <= self.typeReset
+            self.reset.value = self.typeReset
 
         yield Timer(self.halfPeriod * 5)
 
         if self.reset:
-            self.reset <= int(1 if self.typeReset == RESET_ACTIVE_LEVEL.LOW else 0)
+            self.reset.value = int(1 if self.typeReset == RESET_ACTIVE_LEVEL.LOW else 0)
 
 
     ##########################################################################
@@ -70,9 +70,9 @@ class ClockDomain:
     @cocotb.coroutine
     def _clkGen(self):
         while True:
-            self.clk <= 0
+            self.clk.value = 0
             yield Timer(self.halfPeriod)
-            self.clk <= 1
+            self.clk.value = 1
             yield Timer(self.halfPeriod)
 
 

--- a/Flow.py
+++ b/Flow.py
@@ -26,7 +26,7 @@ class Flow:
     #==========================================================================
     def startMonitoringValid(self, clk):
         self.clk  = clk
-        self.fork_valid = cocotb.fork(self.monitor_valid())
+        self.fork_valid = cocotb.start_soon(self.monitor_valid())
 
 
     #==========================================================================

--- a/Flow.py
+++ b/Flow.py
@@ -1,6 +1,6 @@
 import cocotb
 from cocotb.triggers import RisingEdge, Event
-from cocotblib.misc import Bundle
+from .misc import Bundle
 
 
 ###############################################################################

--- a/Scorboard.py
+++ b/Scorboard.py
@@ -3,7 +3,7 @@ from queue import Queue
 import cocotb
 from cocotb.result import TestFailure
 
-from cocotblib.Phase import Infrastructure, PHASE_CHECK_SCORBOARDS
+from .Phase import Infrastructure, PHASE_CHECK_SCORBOARDS
 
 
 class ScorboardInOrder(Infrastructure):

--- a/Spi.py
+++ b/Spi.py
@@ -5,8 +5,8 @@ from cocotb.decorators import coroutine
 from cocotb.result import TestFailure, ReturnValue
 from cocotb.triggers import RisingEdge, Edge, Timer
 
-from cocotblib.TriState import TriStateOutput
-from cocotblib.misc import log2Up, BoolRandomizer, assertEquals, testBit
+from .TriState import TriStateOutput
+from .misc import log2Up, BoolRandomizer, assertEquals, testBit
 
 
 class SpiMaster:

--- a/Spi.py
+++ b/Spi.py
@@ -40,22 +40,22 @@ class SpiSlaveMaster:
         self.dataWidth = 8
 
     def init(self, cpol, cpha, baudrate, dataWidth = 8):
-        self.spi.ss <= True
+        self.spi.ss.value = True
         self.cpol = cpol
         self.cpha = cpha
         self.baudPeriode = baudrate
         self.dataWidth = dataWidth
-        self.spi.sclk <= cpol
+        self.spi.sclk.value = cpol
 
     @coroutine
     def enable(self):
-        self.spi.ss <= False
+        self.spi.ss.value = False
         yield Timer(self.baudPeriode)
 
     @coroutine
     def disable(self):
         yield Timer(self.baudPeriode)
-        self.spi.ss <= True
+        self.spi.ss.value = True
         yield Timer(self.baudPeriode)
 
     @coroutine
@@ -63,19 +63,19 @@ class SpiSlaveMaster:
         buffer = ""
         if not self.cpha:
             for i in range(self.dataWidth):
-                self.spi.mosi <= testBit(masterData, self.dataWidth - 1 - i)
+                self.spi.mosi.value = testBit(masterData, self.dataWidth - 1 - i)
                 yield Timer(self.baudPeriode >> 1)
                 buffer = buffer + str(self.spi.miso.write) if bool(self.spi.miso.writeEnable) else "x"
-                self.spi.sclk <= (not self.cpol)
+                self.spi.sclk.value = (not self.cpol)
                 yield Timer(self.baudPeriode >> 1)
-                self.spi.sclk <= (self.cpol)
+                self.spi.sclk.value = (self.cpol)
         else:
             for i in range(self.dataWidth):
-                self.spi.mosi <= testBit(masterData, self.dataWidth -1  - i)
-                self.spi.sclk <= (not self.cpol)
+                self.spi.mosi.value = testBit(masterData, self.dataWidth -1  - i)
+                self.spi.sclk.value = (not self.cpol)
                 yield Timer(self.baudPeriode >> 1)
                 buffer = buffer + str(self.spi.miso.write) if bool(self.spi.miso.writeEnable) else "x"
-                self.spi.sclk <= (self.cpol)
+                self.spi.sclk.value = (self.cpol)
                 yield Timer(self.baudPeriode >> 1)
 
         raise ReturnValue(buffer)

--- a/Stream.py
+++ b/Stream.py
@@ -94,11 +94,11 @@ class StreamDriverMaster:
     @cocotb.coroutine
     def stim(self):
         stream = self.stream
-        stream.valid <= 0
+        stream.valid.value = 0
         while True:
             yield RisingEdge(self.clk)
             if int(stream.valid) == 1 and int(stream.ready) == 1:
-                stream.valid <= 0
+                stream.valid.value = 0
                 for i in range(nextDelay):
                     yield RisingEdge(self.clk)
 
@@ -112,12 +112,12 @@ class StreamDriverMaster:
                         nextDelay = trans.nextDelay
                     else:
                         nextDelay = 0
-                    stream.valid <= 1
+                    stream.valid.value = 1
 
                     for name in stream.payload.nameToElement:
                         if hasattr(trans,name) == False:
                             raise Exception("Missing element in bundle :" + name)
-                        e = stream.payload.nameToElement[name] <= getattr(trans,name)
+                        e = stream.payload.nameToElement[name].value = getattr(trans,name)
 
 
 
@@ -132,10 +132,10 @@ class StreamDriverSlave:
     @cocotb.coroutine
     def stim(self):
         stream = self.stream
-        stream.ready <= 1
+        stream.ready.value = 1
         while True:
             yield RisingEdge(self.clk)
-            stream.ready <= self.randomizer.get()
+            stream.ready.value = self.randomizer.get()
 
 
 def TransactionFromBundle(bundle):

--- a/Stream.py
+++ b/Stream.py
@@ -20,11 +20,11 @@ class Stream:
 
     def startMonitoringReady(self, clk):
         self.clk  = clk
-        self.fork_ready = cocotb.fork(self.monitor_ready())
+        self.fork_ready = cocotb.start_soon(self.monitor_ready())
 
     def startMonitoringValid(self, clk):
         self.clk  = clk
-        self.fork_valid = cocotb.fork(self.monitor_valid())
+        self.fork_valid = cocotb.start_soon(self.monitor_valid())
 
     def stopMonitoring(self):
         self.fork_ready.kill()
@@ -89,7 +89,7 @@ class StreamDriverMaster:
         self.reset = reset
         self.transactor = transactor
 
-        cocotb.fork(self.stim())
+        cocotb.start_soon(self.stim())
 
     @cocotb.coroutine
     def stim(self):
@@ -127,7 +127,7 @@ class StreamDriverSlave:
         self.clk = clk
         self.reset = reset
         self.randomizer = BoolRandomizer()
-        cocotb.fork(self.stim())
+        cocotb.start_soon(self.stim())
 
     @cocotb.coroutine
     def stim(self):
@@ -151,7 +151,7 @@ class StreamMonitor:
         self.callback = callback
         self.clk = clk
         self.reset = reset
-        cocotb.fork(self.stim())
+        cocotb.start_soon(self.stim())
 
     @cocotb.coroutine
     def stim(self):

--- a/Stream.py
+++ b/Stream.py
@@ -3,10 +3,10 @@ import cocotb
 import types
 from cocotb.result import TestFailure
 from cocotb.triggers import RisingEdge, Timer, Event
-from cocotblib.Phase import Infrastructure, PHASE_WAIT_TASKS_END
-from cocotblib.Scorboard import ScorboardInOrder
+from .Phase import Infrastructure, PHASE_WAIT_TASKS_END
+from .Scorboard import ScorboardInOrder
 
-from cocotblib.misc import Bundle, BoolRandomizer
+from .misc import Bundle, BoolRandomizer
 
 
 class Stream:

--- a/misc.py
+++ b/misc.py
@@ -30,10 +30,10 @@ def randBits(width):
     return random.getrandbits(width)
 
 def randSignal(that):
-    that <= random.getrandbits(len(that))
+    that.value = random.getrandbits(len(that))
 
 def randBoolSignal(that,prob):
-    that <= (random.random() < prob)
+    that.value = (random.random() < prob)
 
 
 @coroutine
@@ -86,15 +86,15 @@ def sint(signal):
 @cocotb.coroutine
 def ClockDomainAsyncReset(clk,reset,period = 1000):
     if reset:
-        reset <= 1
-    clk <= 0
+        reset.value = 1
+    clk.value = 0
     yield Timer(period)
     if reset:
-        reset <= 0
+        reset.value = 0
     while True:
-        clk <= 0
+        clk.value = 0
         yield Timer(period/2)
-        clk <= 1
+        clk.value = 1
         yield Timer(period/2)
 
 @cocotb.coroutine
@@ -154,15 +154,15 @@ def StreamRandomizer(streamName, onNew,handle, dut, clk):
     ready = getattr(dut, streamName + "_ready")
     payloads = [a for a in dut if a._name.startswith(streamName + "_payload")]
 
-    valid <= 0
+    valid.value = 0
     while True:
         yield RisingEdge(clk)
         if int(ready) == 1:
-            valid <= 0
+            valid.value = 0
 
         if int(valid) == 0 or int(ready) == 1:
             if validRandomizer.get():
-                valid <= 1
+                valid.value = 1
                 for e in payloads:
                     randSignal(e)
                 yield Timer(1)
@@ -181,11 +181,11 @@ def FlowRandomizer(streamName, onNew,handle, dut, clk):
     valid = getattr(dut, streamName + "_valid")
     payloads = [a for a in dut if a._name.startswith(streamName + "_payload")]
 
-    valid <= 0
+    valid.value = 0
     while True:
         yield RisingEdge(clk)
         if validRandomizer.get():
-            valid <= 1
+            valid.value = 1
             for e in payloads:
                 randSignal(e)
             yield Timer(1)
@@ -198,7 +198,7 @@ def FlowRandomizer(streamName, onNew,handle, dut, clk):
             if onNew:
                 onNew(payload,handle)
         else:
-            valid <= 0
+            valid.value = 0
 
 @cocotb.coroutine
 def StreamReader(streamName, onTransaction, handle, dut, clk):
@@ -207,10 +207,10 @@ def StreamReader(streamName, onTransaction, handle, dut, clk):
     ready = getattr(dut, streamName + "_ready")
     payloads = [a for a in dut if a._name.startswith(streamName + "_payload")]
 
-    ready <= 0
+    ready.value = 0
     while True:
         yield RisingEdge(clk)
-        ready <= validRandomizer.get()
+        ready.value = validRandomizer.get()
         if int(valid) == 1 and int(ready) == 1:
             if len(payloads) == 1 and payloads[0]._name == streamName + "_payload":
                 payload = int(payloads[0])


### PR DESCRIPTION
LOW risk changes

This is a FAST-FORWARD on top of 02of20, merge with rebase.

20of20 (dlmiles/SpinalHDL-CocotbLib.git#f705aa3e8) test results below:

```
# git log -n3 --oneline --format="%h %d %cd %s"
b092475ca  (HEAD -> dev) Wed May 17 10:37:37 2023 +0000 .gitmodules: ADDED https://github.com/dlmiles/SpinalHDL-CocotbLib.git#dlm-cleanup#f705aa3e8c
e26329834  Wed May 17 10:36:57 2023 +0000 .gitmodules: REMOVE
d15b083a7  (github/dev) Tue May 16 13:23:25 2023 +0100 Add PhaseRandomizedMem
```

```
# git diff HEAD~2..HEAD
diff --git a/.gitmodules b/.gitmodules
index 0bb3f0921..073f2a372 100644
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tester/src/test/python/cocotblib"]
        path = tester/src/test/python/cocotblib
-       url = https://github.com/SpinalHDL/CocotbLib.git
+       url = https://github.com/dlmiles/SpinalHDL-CocotbLib.git
+       branch = dlm-cleanup
diff --git a/tester/src/test/python/cocotblib b/tester/src/test/python/cocotblib
index a98830423..f705aa3e8 160000
--- a/tester/src/test/python/cocotblib
+++ b/tester/src/test/python/cocotblib
@@ -1 +1 @@
-Subproject commit a98830423924fc89bfebae84cb802fc90d352602
+Subproject commit f705aa3e8c9ed4e9290f50e6051ef353a5121113
```
